### PR TITLE
Button Corner Radius

### DIFF
--- a/packages/react-native-payments/docs/ApplePayButton.md
+++ b/packages/react-native-payments/docs/ApplePayButton.md
@@ -24,13 +24,14 @@ In addition to button's type, you can set button's visual appearance. For iOS an
 ![Apple pay button - styles](https://user-images.githubusercontent.com/829963/40891711-daca8ff8-678a-11e8-89f2-26a0c3dcf9ed.png)
 
 ## Props
-| Prop name | required | Type        | Default Value |
-|-----------|----------|-------------|---------------|
-| type      | yes      | ButtonType  |               |
-| style     | yes      | ButtonStyle |               |
-| onPress   | yes      | Function    |               |
-| width     | no       | number      |               |
-| height    | no       | number      | 44            |
+| Prop name    | required | Type        | Default Value |
+|--------------|----------|-------------|---------------|
+| type         | yes      | ButtonType  |               |
+| style        | yes      | ButtonStyle |               |
+| onPress      | yes      | Function    |               |
+| width        | no       | number      |               |
+| height       | no       | number      | 44            |
+| cornerRadius | no       | number      | 4             |
 
 ## Types
 ```javascript

--- a/packages/react-native-payments/lib/ios/Views/PKPaymentButtonManager.m
+++ b/packages/react-native-payments/lib/ios/Views/PKPaymentButtonManager.m
@@ -30,6 +30,13 @@ RCT_CUSTOM_VIEW_PROPERTY(buttonStyle, NSString, PKPaymentButtonView)
   }
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(cornerRadius, CGFloat, PKPaymentButtonView)
+{
+  if (json) {
+    [view setCornerRadius:[RCTConvert CGFloat:json]];
+  }
+}
+
 - (UIView *) view
 {
   return [PKPaymentButtonView new];

--- a/packages/react-native-payments/lib/ios/Views/PKPaymentButtonView.h
+++ b/packages/react-native-payments/lib/ios/Views/PKPaymentButtonView.h
@@ -13,6 +13,7 @@
 
 @property (strong, nonatomic) NSString *buttonStyle;
 @property (strong, nonatomic) NSString *buttonType;
+@property (nonatomic) CGFloat cornerRadius;
 @property (nonatomic, readonly) PKPaymentButton *button;
 @property (nonatomic, copy) RCTBubblingEventBlock onPress;
 

--- a/packages/react-native-payments/lib/ios/Views/PKPaymentButtonView.m
+++ b/packages/react-native-payments/lib/ios/Views/PKPaymentButtonView.m
@@ -10,35 +10,45 @@
 
 NSString * const DEFAULT_BUTTON_TYPE = @"plain";
 NSString * const DEFAULT_BUTTON_STYLE = @"black";
+CGFloat const DEFAULT_CORNER_RADIUS = 4.0;
 
 @implementation PKPaymentButtonView
 
 @synthesize buttonType = _buttonType;
 @synthesize buttonStyle = _buttonStyle;
+@synthesize cornerRadius = _cornerRadius;
 @synthesize button = _button;
 
 - (instancetype) init {
   self = [super init];
-  
-  [self setButtonType:DEFAULT_BUTTON_TYPE andStyle:DEFAULT_BUTTON_STYLE];
-  
+
+  [self setButtonType:DEFAULT_BUTTON_TYPE andStyle:DEFAULT_BUTTON_STYLE withRadius:DEFAULT_CORNER_RADIUS];
+
   return self;
 }
 
 - (void)setButtonType:(NSString *) value {
   if (_buttonType != value) {
-    [self setButtonType:value andStyle:_buttonStyle];
+    [self setButtonType:value andStyle:_buttonStyle withRadius:_cornerRadius];
   }
-  
+
   _buttonType = value;
 }
 
 - (void)setButtonStyle:(NSString *) value {
   if (_buttonStyle != value) {
-    [self setButtonType:_buttonType andStyle:value];
+    [self setButtonType:_buttonType andStyle:value withRadius:_cornerRadius];
   }
-  
+
   _buttonStyle = value;
+}
+
+- (void)setCornerRadius:(CGFloat) value {
+  if (_cornerRadius != value) {
+    [self setButtonType:_buttonType andStyle:_buttonStyle withRadius:value];
+  }
+
+  _cornerRadius = value;
 }
 
 /**
@@ -46,14 +56,14 @@ NSString * const DEFAULT_BUTTON_STYLE = @"black";
  * unmount existint button and create new one whenever it's style and/or
  * type is changed.
  */
-- (void)setButtonType:(NSString *) buttonType andStyle:(NSString *) buttonStyle {
+- (void)setButtonType:(NSString *) buttonType andStyle:(NSString *) buttonStyle withRadius:(CGFloat) cornerRadius {
   for (UIView *view in self.subviews) {
     [view removeFromSuperview];
   }
 
   PKPaymentButtonType type;
   PKPaymentButtonStyle style;
-  
+
   if ([buttonType isEqualToString: @"buy"]) {
     type = PKPaymentButtonTypeBuy;
   } else if ([buttonType isEqualToString: @"setUp"]) {
@@ -76,7 +86,17 @@ NSString * const DEFAULT_BUTTON_STYLE = @"black";
 
   _button = [[PKPaymentButton alloc] initWithPaymentButtonType:type paymentButtonStyle:style];
   [_button addTarget:self action:@selector(touchUpInside:) forControlEvents:UIControlEventTouchUpInside];
-  
+
+  if (@available(iOS 12.0, *)) {
+    _button.cornerRadius = cornerRadius;
+  } else {
+    // this fallback will only work for values >= 4,
+    // since it is affecting the layer and not the button
+    // which is already rounded by default.
+    _button.layer.cornerRadius = cornerRadius;
+    _button.layer.masksToBounds = true;
+  }
+
   [self addSubview:_button];
 }
 

--- a/packages/react-native-payments/lib/js/PKPaymentButton.js
+++ b/packages/react-native-payments/lib/js/PKPaymentButton.js
@@ -28,6 +28,7 @@ type Props = $Exact<{
   type: ButtonType,
   width?: number,
   height?: number,
+  cornerRadius: number,
   onPress: Function,
 }>;
 
@@ -44,6 +45,7 @@ export class PKPaymentButton extends React.Component<Props> {
     buttonStyle: 'black',
     buttonType: 'plain',
     height: 44,
+    cornerRadius: 4,
   };
 
   render() {
@@ -54,6 +56,7 @@ export class PKPaymentButton extends React.Component<Props> {
         onPress={this.props.onPress}
         width={this.props.width}
         height={this.props.height}
+        cornerRadius={this.props.cornerRadius}
       />
     );
   }


### PR DESCRIPTION
This adds support for the `PkPaymentButton`'s `cornerRadius` property. Documentation [here](https://developer.apple.com/documentation/passkit/pkpaymentbutton/2999416-cornerradius).

This property is only supported on iOS 12 and greater, so for previous versions it will set the corner radius on the layer instead. This will work for values >= 4, but won't for less than 4 since the button itself already has radius applied.