### PR TITLE
Donate Button Fallback

### DIFF
--- a/packages/react-native-payments/lib/ios/Views/PKPaymentButtonView.m
+++ b/packages/react-native-payments/lib/ios/Views/PKPaymentButtonView.m
@@ -71,7 +71,11 @@ CGFloat const DEFAULT_CORNER_RADIUS = 4.0;
   } else if ([buttonType isEqualToString: @"inStore"]) {
     type = PKPaymentButtonTypeInStore;
   } else if ([buttonType isEqualToString: @"donate"]) {
-    type = PKPaymentButtonTypeDonate;
+    if (@available(iOS 10.2, *)) {
+      type = PKPaymentButtonTypeDonate;
+    } else {
+      type = PKPaymentButtonTypePlain;
+    }
   } else {
     type = PKPaymentButtonTypePlain;
   }


### PR DESCRIPTION
The Donate version of the `PKPaymentButton` is only available for iOS 10.2 and up. Fallback to the plain button if it is not available.